### PR TITLE
feat: update custom component guidelines with formatting restrictions

### DIFF
--- a/agents/detail-regenerator.yaml
+++ b/agents/detail-regenerator.yaml
@@ -54,6 +54,9 @@ input_schema:
     feedback:
       type: string
       description: Feedback for content improvement
+    reset:
+      type: boolean
+      description: Ignore previous results and regenerate content from scratch
 output_schema:
   type: object
   properties:

--- a/agents/find-items-by-paths.mjs
+++ b/agents/find-items-by-paths.mjs
@@ -7,7 +7,7 @@ import {
 } from "../utils/docs-finder-utils.mjs";
 
 export default async function selectedDocs(
-  { docs, structurePlanResult, boardId, docsDir, isTranslate, feedback, locale },
+  { docs, structurePlanResult, boardId, docsDir, isTranslate, feedback, locale, reset = false },
   options,
 ) {
   let foundItems = [];
@@ -100,6 +100,14 @@ export default async function selectedDocs(
 
   // Add feedback to all results if provided
   foundItems = addFeedbackToItems(foundItems, userFeedback);
+
+  // if reset is true, set content to null for all items
+  if (reset) {
+    foundItems = foundItems.map((item) => ({
+      ...item,
+      content: null,
+    }));
+  }
 
   return {
     selectedDocs: foundItems,

--- a/agents/load-sources.mjs
+++ b/agents/load-sources.mjs
@@ -19,6 +19,7 @@ export default async function loadSources({
   boardId,
   useDefaultPatterns = true,
   lastGitHead,
+  reset = false,
 } = {}) {
   let files = Array.isArray(sources) ? [...sources] : [];
 
@@ -190,7 +191,7 @@ export default async function loadSources({
 
   // Get the last output result of the specified path
   let content;
-  if (docPath) {
+  if (docPath && !reset) {
     let fileFullName;
 
     // First try direct path matching (original format)

--- a/prompts/document/custom-components.md
+++ b/prompts/document/custom-components.md
@@ -1,3 +1,4 @@
+<custom_component>
 When generating document details, you can use the following custom components at appropriate locations based on their descriptions and functionality to enhance document presentation:
 - `<x-card>`
 - `<x-cards>`
@@ -24,7 +25,11 @@ Attribute Rules:
 -	data-href (optional): Navigation link for clicking the card or button.
 -	data-horizontal (optional): Whether to use horizontal layout.
 -	data-cta (optional): Button text (call to action).
--	Body content: Must be written within <x-card>...</x-card> children.
+-	Body content: 
+  - Must be written within <x-card>...</x-card> children.
+  - **Markdown format rendering is not supported**
+  - **Code block rendering is not supported**
+  - Only supports plain text format without styling
 
 
 ### 2. `<x-cards>` Card List Component
@@ -49,32 +54,51 @@ Attribute Rules:
     -	Or all cards should have data-image.
     -	Avoid mixing (some with icons, some with only images).
 
-
-### 3. Examples
+<good_example>
+Use plain text without any styling
+<x-card data-title="alarm()" data-icon="lucide:alarm-clock"> SIGALRM: Sent when a real-time timer has expired.  </x-card>
 
 Single card:
-
-```
 <x-card data-title="Horizontal card" data-icon="lucide:atom" data-horizontal="true">
   This is an example of a horizontal card.
 </x-card>
-```
 
 Card list (all using icons, recommended approach):
-
-```
 <x-cards data-columns="3">
   <x-card data-title="Feature 1" data-icon="lucide:rocket">Description of Feature 1.</x-card>
   <x-card data-title="Feature 2" data-icon="lucide:bolt">Description of Feature 2.</x-card>
   <x-card data-title="Feature 3" data-icon="material-symbols:rocket-outline">Description of Feature 3.</x-card>
 </x-cards>
-```
 
 Card list (all using images):
-
-```
 <x-cards data-columns="2">
   <x-card data-title="Card A" data-image="https://picsum.photos/id/10/300/300">Content A</x-card>
   <x-card data-title="Card B" data-image="https://picsum.photos/id/11/300/300">Content B</x-card>
 </x-cards>
+</good_example>
+
+<bad_example>
+
+`x-card` component body does not support markdown formatting inline code block
+<x-card data-title="alarm()" data-icon="lucide:alarm-clock"> `SIGALRM`: Sent when a real-time timer has expired.  </x-card>
+
+
+`x-card` component body does not support code blocks
+<x-card data-title="ctrl_break()" data-icon="lucide:keyboard">
+Creates a listener for "ctrl-break" events.
+```rust,no_run
+use tokio::signal::windows::ctrl_break;
+
+#[tokio::main]
+async fn main() -> std::io::Result<()> {
+let mut stream = ctrl_break()?;
+stream.recv().await;
+println!("got ctrl-break");
+Ok(())
+}
 ```
+</x-card>
+
+</bad_example>
+
+</custom_component>

--- a/tests/check-detail-result.test.mjs
+++ b/tests/check-detail-result.test.mjs
@@ -146,6 +146,118 @@ describe("checkDetailResult", () => {
       expect(result.isApproved).toBe(false);
       expect(result.detailFeedback).toContain("insufficient indentation");
     });
+
+    test("should approve various programming language code blocks with proper detection", async () => {
+      const structurePlan = [];
+      const reviewContent = `Programming Language Examples:
+
+## Rust with Configuration
+\`\`\`rust,no_run
+use tokio::signal::windows::ctrl_shutdown;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut signal = ctrl_shutdown()?;
+    signal.recv().await;
+    println!("got CTRL-SHUTDOWN. Cleaning up before exiting");
+    Ok(())
+}
+\`\`\`
+
+## C# .NET Example
+\`\`\`c#
+using System;
+using System.Threading.Tasks;
+
+public class Program
+{
+    public static async Task Main(string[] args)
+    {
+        Console.WriteLine("Hello C#!");
+        await Task.Delay(1000);
+    }
+}
+\`\`\`
+
+## C++ with CLI Extension
+\`\`\`c++/cli
+#include <iostream>
+#include <vector>
+
+int main() {
+    std::vector<int> numbers = {1, 2, 3, 4, 5};
+    for (const auto& num : numbers) {
+        std::cout << num << " ";
+    }
+    return 0;
+}
+\`\`\`
+
+## TypeScript with Extension
+\`\`\`typescript.tsx
+interface Props {
+    title: string;
+    count: number;
+}
+
+const Component: React.FC<Props> = ({ title, count }) => {
+    return <div>{title}: {count}</div>;
+};
+
+export default Component;
+\`\`\`
+
+## Python with Version
+\`\`\`python,version=3.9
+import asyncio
+from typing import List, Optional
+
+async def fetch_data(urls: List[str]) -> Optional[dict]:
+    tasks = [asyncio.create_task(process_url(url)) for url in urls]
+    results = await asyncio.gather(*tasks)
+    return {"results": results}
+
+if __name__ == "__main__":
+    asyncio.run(fetch_data(["http://example.com"]))
+\`\`\`
+
+## Shell Script with Latest Tag
+\`\`\`bash:latest
+#!/bin/bash
+set -euo pipefail
+
+function deploy_app() {
+    local app_name="$1"
+    local version="$2"
+    
+    echo "Deploying $app_name version $version"
+    docker run --rm "$app_name:$version"
+}
+
+deploy_app "my-app" "v1.0.0"
+\`\`\`
+
+## Node.js Configuration
+\`\`\`node.js
+const express = require('express');
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+app.get('/health', (req, res) => {
+    res.json({ status: 'ok', timestamp: new Date().toISOString() });
+});
+
+app.listen(PORT, () => {
+    console.log(\`Server running on port \${PORT}\`);
+});
+\`\`\`
+
+This document demonstrates various programming language code blocks.`;
+
+      const result = await checkDetailResult({ structurePlan, reviewContent });
+      expect(result.isApproved).toBe(true);
+      expect(result.detailFeedback).toBe("");
+    });
   });
 
   describe("Content structure validation", () => {

--- a/utils/markdown-checker.mjs
+++ b/utils/markdown-checker.mjs
@@ -243,7 +243,7 @@ function checkLocalImages(markdown, source, errorMessages, markdownFilePath, bas
  */
 function checkContentStructure(markdown, source, errorMessages) {
   const lines = markdown.split("\n");
-  const allCodeBlockRegex = /^\s*```(?:\w+)?$/;
+  const allCodeBlockRegex = /^\s*```(?:[a-zA-Z0-9_,\-+.#/:=]+)?$/;
 
   // State variables for different checks
   let inCodeBlock = false;
@@ -300,7 +300,7 @@ function checkContentStructure(markdown, source, errorMessages) {
   }
 
   // Check if content ends with proper punctuation (indicating completeness)
-  const validEndingPunctuation = [".", "。", ")", "|", "*", ">"];
+  const validEndingPunctuation = [".", "。", ")", "|", "*", ">", "`"];
   const trimmedText = markdown.trim();
   const hasValidEnding = validEndingPunctuation.some((punct) => trimmedText.endsWith(punct));
 


### PR DESCRIPTION
## Related Issue

https://team.arcblock.io/task/task/618263375142453248

### Major Changes

1. 优化自定义组件内容生成，不支持 markdown 格式渲染
2. `update` 命令新增 `reset` 参数，可忽略上次生成的结果重新生成  `aigne doc update --reset`

### Screenshots

<img width="933" height="416" alt="image" src="https://github.com/user-attachments/assets/819e5adc-03f6-472e-948e-7d4ff23ee95c" />

<img width="877" height="569" alt="image" src="https://github.com/user-attachments/assets/aa572e6e-1353-474b-a7f5-5acadd885e4b" />

### Test Plan

- [ ] 文档生成，正常使用自定义组件，不包含 markdown 格式内容，特别是代码块
- [ ] 使用 `--reset` 参数，生成时忽略上次生成结果

### Checklist

- [ ] This change requires documentation updates, and I have updated the relevant documentation. If the documentation has not been updated, please create a documentation update issue and link it here
- [x] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts
- [ ] The newly added code logic is also covered by tests
- [ ] This change adds dependencies, and they are placed in dependencies and devDependencies
- [ ] This change includes adding or updating npm dependencies, and it does not result in multiple versions of the same dependency [check the diff of pnpm-lock.yaml]

<!-- This is an auto-generated comment: release notes by AIGNE CodeSmith -->
### Summary by AIGNE

Release Notes:

- New Feature: Enhanced code block language support, now accepting a wider range of programming language specifiers including Rust, C#, C++, TypeScript, Python, Shell, and Node.js with their various configurations
- New Feature: Added reset option for document processing, allowing users to bypass previous output results when needed
- Test: Added comprehensive test coverage for code block detection across multiple programming languages

These updates improve the system's ability to handle diverse code examples and provide more flexible document processing options.
<!-- end of auto-generated comment: release notes by AIGNE CodeSmith -->