### PR TITLE
fix(ux): make background transparent for d2 diagrams

### DIFF
--- a/prompts/document/d2-chart/rules.md
+++ b/prompts/document/d2-chart/rules.md
@@ -118,6 +118,17 @@ Container labels can be assigned using shorthand (`gcloud: "Google Cloud" {}`) o
 
 When a container has more than three child nodes, use `grid-columns` to limit the number of columns in a single row, preferably to 2 or at most 3, to improve readability. If a container has nested containers, it is recommended to use `grid-gap` (with a value greater than 100) to increase the spacing between them.
 
+- **Bad Practice (Grid Layout):**
+  ```d2
+  Instance: {
+    A: "A"
+    B: "B"
+    C: "C"
+    D: "D"
+    E: "E"
+    F: "F"
+  }
+  ```
 - **Good Practice (Grid Layout):**
   ```d2
   Instance: {

--- a/utils/constants.mjs
+++ b/utils/constants.mjs
@@ -521,7 +521,7 @@ export const D2_CONFIG = `vars: {
       N5: "#E6E8EC"
 
       B3: "#FFE9D1"
-      B4: "#FFE9D1"
+      B4: "transparent"
 
       AA2: "#421E0B"
       AA4: "#FFE9D1"


### PR DESCRIPTION
## Related Issue
<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

### Major Changes
<!--
  @example:
    1. Fixed xxx
    2. Improved xxx
    3. Adjusted xxx
-->
1. use transparent bg in d2 container

### Screenshots
<!-- If the changes are related to the UI, whether CLI or WEB, screenshots should be included -->
before
<img width="890" height="1033" alt="image" src="https://github.com/user-attachments/assets/6e1847f5-45dc-4a72-8a4c-bbcf87322917" />

after
<img width="881" height="1027" alt="image" src="https://github.com/user-attachments/assets/54b81fc2-aa28-42fb-acce-5c640c3c146a" />

### Test Plan

<!-- If this change is not covered by automated tests, what is your test case collection? Please write it as a to-do list below -->

### Checklist

- [x] This change requires documentation updates, and I have updated the relevant documentation. If the documentation has not been updated, please create a documentation update issue and link it here
- [x] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts
- [x] The newly added code logic is also covered by tests
- [x] This change adds dependencies, and they are placed in dependencies and devDependencies
- [x] This change includes adding or updating npm dependencies, and it does not result in multiple versions of the same dependency [check the diff of pnpm-lock.yaml]

<!-- This is an auto-generated comment: release notes by AIGNE CodeSmith -->
### Summary by AIGNE

- Style: Changed D2 container background from light peach to transparent

This visual update removes the peach-colored background (#FFE9D1) from the D2 container, replacing it with a transparent background. The change creates a cleaner look that better integrates with surrounding elements.
<!-- end of auto-generated comment: release notes by AIGNE CodeSmith -->