### PR TITLE
fix: remove dynamic action text from feedback prompts

### DIFF
--- a/agents/utils/choose-docs.mjs
+++ b/agents/utils/choose-docs.mjs
@@ -103,10 +103,7 @@ export default async function chooseDocs(
   // Prompt for feedback if not provided
   let userFeedback = feedback;
   if (!userFeedback) {
-    const feedbackMessage = getActionText(
-      isTranslate,
-      "How should we improve this {action}? (press Enter to skip):",
-    );
+    const feedbackMessage = "How should we improve this document? (press Enter to skip):";
 
     userFeedback = await options.prompts.input({
       message: feedbackMessage,

--- a/agents/utils/find-item-by-path.mjs
+++ b/agents/utils/find-item-by-path.mjs
@@ -97,11 +97,7 @@ export default async function findItemByPath(
   // Prompt for feedback if not provided
   let userFeedback = feedback;
   if (!userFeedback) {
-    const feedbackMessage = getActionText(
-      isTranslate,
-      "How should we improve this {action}? (press Enter to skip):",
-    );
-
+    const feedbackMessage = "How should we improve this document? (press Enter to skip):";
     userFeedback = await options.prompts.input({
       message: feedbackMessage,
     });

--- a/tests/agents/utils/choose-docs.test.mjs
+++ b/tests/agents/utils/choose-docs.test.mjs
@@ -257,10 +257,6 @@ describe("chooseDocs utility", () => {
 
     const result = await chooseDocs(input, mockOptions);
 
-    expect(getActionTextSpy).toHaveBeenCalledWith(
-      true,
-      "How should we improve this {action}? (press Enter to skip):",
-    );
     expect(mockOptions.prompts.input).toHaveBeenCalled();
     expect(result.feedback).toBe("Test feedback");
   });

--- a/tests/agents/utils/find-item-by-path.test.mjs
+++ b/tests/agents/utils/find-item-by-path.test.mjs
@@ -363,7 +363,7 @@ describe("find-item-by-path", () => {
   // FEEDBACK HANDLING TESTS
   test("should prompt for feedback when not provided", async () => {
     mockOptions.prompts.input = async (options) => {
-      expect(options.message).toBe("How should we improve this {action}? (press Enter to skip):");
+      expect(options.message).toBe("How should we improve this document? (press Enter to skip):");
       return "prompted feedback";
     };
 
@@ -379,10 +379,6 @@ describe("find-item-by-path", () => {
       mockOptions,
     );
 
-    expect(getActionTextSpy).toHaveBeenCalledWith(
-      false,
-      "How should we improve this {action}? (press Enter to skip):",
-    );
     expect(result.feedback).toBe("prompted feedback");
   });
 
@@ -456,11 +452,6 @@ describe("find-item-by-path", () => {
         locale: "en",
       },
       mockOptions,
-    );
-
-    expect(getActionTextSpy).toHaveBeenCalledWith(
-      true,
-      "How should we improve this {action}? (press Enter to skip):",
     );
   });
 


### PR DESCRIPTION
## Related Issue

https://team.arcblock.io/task/task/619799993179439104

### Major Changes

1. 优化更新、翻译文档时询问反馈的文案

### Screenshots

<img width="559" height="211" alt="image" src="https://github.com/user-attachments/assets/727f3db2-562e-4c88-b851-b548c4e4bcde" />

### Test Plan

- [x] 更新文档
- [x] 翻译文档

### Checklist

- [ ] This change requires documentation updates, and I have updated the relevant documentation. If the documentation has not been updated, please create a documentation update issue and link it here
- [x] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts
- [ ] The newly added code logic is also covered by tests
- [ ] This change adds dependencies, and they are placed in dependencies and devDependencies
- [ ] This change includes adding or updating npm dependencies, and it does not result in multiple versions of the same dependency [check the diff of pnpm-lock.yaml]

<!-- This is an auto-generated comment: release notes by AIGNE CodeSmith -->
### Summary by AIGNE

**Refactor**:
- Simplified and standardized the feedback collection prompt across the application to consistently display "How should we improve this document? (press Enter to skip):"

**Test**:
- Updated test suites to align with the new standardized feedback prompt implementation

This change streamlines the user experience by providing a consistent feedback collection interface, removing variable messaging that could cause confusion. Users will now see the same clear, straightforward prompt when asked to provide document improvement suggestions.
<!-- end of auto-generated comment: release notes by AIGNE CodeSmith -->