### PR TITLE
fix: update doc-smith logo

### DIFF
--- a/.aigne/doc-smith/config.yaml
+++ b/.aigne/doc-smith/config.yaml
@@ -1,7 +1,7 @@
 # Project information for documentation publishing
 projectName: AIGNE DocSmith
 projectDesc: AIGNE DocSmith is a powerful, AI-driven documentation generation tool built on the AIGNE Framework. It automates the creation of detailed, structured, and multi-language documentation directly from your source code.
-projectLogo: https://docsmith.aigne.io/image-bin/uploads/a7910a71364ee15a27e86f869ad59009.svg
+projectLogo: https://docsmith.aigne.io/image-bin/uploads/9645caf64b4232699982c4d940b03b90.svg
 
 # =============================================================================
 # Documentation Configuration

--- a/.aigne/doc-smith/preferences.yml
+++ b/.aigne/doc-smith/preferences.yml
@@ -9,7 +9,7 @@ rules:
     active: true
     scope: document
     rule: When describing publishing options, should use plain text instead of custom components, and recommend users to run their own Discuss Kit instance while providing relevant links.
-    feedback: Publishing options should not use custom components: recommend users to run their own Discuss Kit instance in the text, and add Discuss Kit related links
+    feedback: "Publishing options should not use custom components: recommend users to run their own Discuss Kit instance in the text, and add Discuss Kit related links"
     createdAt: 2025-09-07T02:18:22.237Z
   - id: pref_039b58c47bdf95c9
     active: true

--- a/utils/auth-utils.mjs
+++ b/utils/auth-utils.mjs
@@ -91,7 +91,7 @@ export async function getAccessToken(appUrl, ltToken = "") {
       source: `AIGNE DocSmith connect to website`,
       closeOnSuccess: true,
       appName: "AIGNE DocSmith",
-      appLogo: "https://docsmith.aigne.io/image-bin/uploads/a7910a71364ee15a27e86f869ad59009.svg",
+      appLogo: "https://docsmith.aigne.io/image-bin/uploads/9645caf64b4232699982c4d940b03b90.svg",
       openPage: (pageUrl) => {
         const url = new URL(pageUrl);
         if (ltToken) {


### PR DESCRIPTION
## Related Issue

https://team.arcblock.io/task/task/622365235252035584

### Major Changes

1. 更新授权 Access Token 页面 DocSmith 的 Logo

### Screenshots

<img width="1434" height="1524" alt="image" src="https://github.com/user-attachments/assets/b2ab4d70-ae31-4254-b149-1df4cfd6bb8c" />

### Test Plan

- [x] 验证授权页面显示新的 Logo

### Checklist

不适用

<!-- This is an auto-generated comment: release notes by AIGNE CodeSmith -->
### Summary by AIGNE

**Chore**: Logo URL Updates

- Chore: Updated DocSmith logo URL across configuration files and authentication utilities
- Style: Improved string formatting in authorization page feedback messages

These changes ensure consistent branding across the application with no functional impact to users. The updates maintain the existing user experience while standardizing the logo display throughout the platform.
<!-- end of auto-generated comment: release notes by AIGNE CodeSmith -->