### PR TITLE
fix: improve configuration review text clarity

### DIFF
--- a/agents/generate/check-need-generate-structure.mjs
+++ b/agents/generate/check-need-generate-structure.mjs
@@ -21,11 +21,11 @@ export default async function checkNeedGenerateStructure(
         "Your project configuration is complete. Would you like to generate the document structure now?",
       choices: [
         {
-          name: "Generate now - Start building the document structure",
+          name: "Generate now - Start generating the document structure",
           value: "generate",
         },
         {
-          name: "Review configuration first - Modify settings before generating",
+          name: "Review configuration first - Edit configuration before generating",
           value: "later",
         },
       ],
@@ -34,7 +34,7 @@ export default async function checkNeedGenerateStructure(
     if (choice === "later") {
       console.log(`\nConfiguration file: ${chalk.cyan("./.aigne/doc-smith/config.yaml")}`);
       console.log(
-        "Review and modify your configuration as needed, then run 'aigne doc generate' to continue.",
+        "Review and edit your configuration as needed, then run 'aigne doc generate' to continue.",
       );
 
       // In test environment, return a special result instead of exiting

--- a/agents/generate/user-review-document-structure.mjs
+++ b/agents/generate/user-review-document-structure.mjs
@@ -74,7 +74,7 @@ export default async function userReviewDocumentStructure({ documentStructure, .
   // Ask user if they want to review the document structure
   const needReview = await options.prompts.select({
     message:
-      "Would you like to optimize the document structure?\n  You can modify titles, reorganize sections.",
+      "Would you like to optimize the document structure?\n  You can edit titles, reorganize sections.",
     choices: [
       {
         name: "Looks good - proceed with current structure",
@@ -141,9 +141,6 @@ export default async function userReviewDocumentStructure({ documentStructure, .
         currentStructure = result.documentStructure;
       }
 
-      // Print current document structure in a user-friendly format
-      printDocumentStructure(currentStructure);
-
       // Check if feedback should be saved as user preference
       const feedbackRefinerAgent = options.context.agents["checkFeedbackRefiner"];
       if (feedbackRefinerAgent) {
@@ -157,6 +154,9 @@ export default async function userReviewDocumentStructure({ documentStructure, .
           console.warn("Your feedback was applied but not saved as a preference.");
         }
       }
+
+      // Print current document structure in a user-friendly format
+      printDocumentStructure(currentStructure);
     } catch (error) {
       console.error("Error processing your feedback:");
       console.error(`Type: ${error.name}`);


### PR DESCRIPTION
## Related Issue

https://team.arcblock.io/task/task/611187453012738048

### Major Changes

1. 统一提示中的文案：
  - 统一使用 "configuration" 
  - 统一使用 "edit" 

2. 总结用户为偏好执行结束后，再打印优化后的文档结构

### Screenshots

<img width="870" height="132" alt="image" src="https://github.com/user-attachments/assets/e1d564d3-e0e4-40d3-8309-67c24420528d" />

<img width="1212" height="175" alt="image" src="https://github.com/user-attachments/assets/6014d7ab-9af0-43b2-a6e9-9f7d9f012924" />


### Test Plan

- [x] 验证文案的修改
- [x] 调整优化文档结构打印的时机

### Checklist

- [ ] This change requires documentation updates, and I have updated the relevant documentation. If the documentation has not been updated, please create a documentation update issue and link it here
- [ ] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts
- [ ] The newly added code logic is also covered by tests
- [ ] This change adds dependencies, and they are placed in dependencies and devDependencies
- [ ] This change includes adding or updating npm dependencies, and it does not result in multiple versions of the same dependency [check the diff of pnpm-lock.yaml]

<!-- This is an auto-generated comment: release notes by AIGNE CodeSmith -->
### Summary by AIGNE

**Refactor: Terminology Standardization**

- Refactor: Standardized terminology across document structure generation workflow, using consistent terms like "configuration" and "edit"
- Refactor: Improved clarity of user interface text by replacing "building" with "generating" for document operations
- Refactor: Enhanced user feedback flow by optimizing the sequence of document structure display and preference handling

These changes provide a more cohesive and intuitive user experience when working with document structure generation features.
<!-- end of auto-generated comment: release notes by AIGNE CodeSmith -->