### PR TITLE
fix: treat description as text node instead of markdown attribute value

### DIFF
--- a/prompts/detail/custom/custom-components.md
+++ b/prompts/detail/custom/custom-components.md
@@ -115,6 +115,7 @@ Nesting Rules:
 
 - **Context types must use `<x-field>` instead of tables** for consistent formatting
 - **Mandatory markdown attribute**: Every `<x-field-desc>` element must include `markdown` attribute
+- **Description text as child content**: Description text must be provided as child content of `<x-field-desc>`, not as the value of the `markdown` attribute
 
 **Error Examples:**
 
@@ -125,7 +126,14 @@ Nesting Rules:
 </x-field>
 ```
 
-✅ **CORRECT** - With required `markdown` attribute:
+❌ **INCORRECT** - Description text as attribute value:
+```
+<x-field data-name="api_key" data-type="string" data-required="true">
+  <x-field-desc markdown="Your **API key** for authentication."></x-field-desc>
+</x-field>
+```
+
+✅ **CORRECT** - Includes the required `markdown` attribute, with the description provided as child text:
 ```
 <x-field data-name="api_key" data-type="string" data-required="true">
   <x-field-desc markdown>Your **API key** for authentication.</x-field-desc>


### PR DESCRIPTION
## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

hotfix

### Major Changes

<!--
  @example:
    1. Fixed xxx
    2. Improved xxx
    3. Adjusted xxx
-->

1. fix: treat description as text node instead of markdown attribute value

### Screenshots

<!-- If the changes are related to the UI, whether CLI or WEB, screenshots should be included -->

<img width="1076" height="217" alt="image" src="https://github.com/user-attachments/assets/5fed8aaa-750d-4524-86d6-6a2c513d711d" />

### Test Plan

<!-- If this change is not covered by automated tests, what is your test case collection? Please write it as a to-do list below -->

### Checklist

- [x] This change requires documentation updates, and I have updated the relevant documentation. If the documentation has not been updated, please create a documentation update issue and link it here
- [x] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts
- [x] The newly added code logic is also covered by tests
- [x] This change adds dependencies, and they are placed in dependencies and devDependencies
- [x] This change includes adding or updating npm dependencies, and it does not result in multiple versions of the same dependency [check the diff of pnpm-lock.yaml]
