### PR TITLE
fix: fix polish update doc select

### DIFF
--- a/agents/clear/index.yaml
+++ b/agents/clear/index.yaml
@@ -7,6 +7,7 @@ skills:
   - url: ../init/index.mjs
     default_input:
       skipIfExists: true
+      checkOnly: true
   - ./choose-contents.mjs
 input_schema:
   type: object

--- a/agents/evaluate/index.yaml
+++ b/agents/evaluate/index.yaml
@@ -5,6 +5,7 @@ skills:
   - url: ../init/index.mjs
     default_input:
       skipIfExists: true
+      checkOnly: true
   - ../utils/load-sources.mjs
   - ../utils/format-document-structure.mjs
   - type: transform

--- a/agents/init/index.mjs
+++ b/agents/init/index.mjs
@@ -32,9 +32,27 @@ const _PRESS_ENTER_TO_FINISH = "Press Enter to finish";
  * @returns {Promise<Object>}
  */
 export default async function init(
-  { outputPath = ".aigne/doc-smith", fileName = "config.yaml", skipIfExists = false, appUrl },
+  {
+    outputPath = ".aigne/doc-smith",
+    fileName = "config.yaml",
+    skipIfExists = false,
+    appUrl,
+    checkOnly = false,
+  },
   options,
 ) {
+  // Check if we're in checkOnly mode
+  if (checkOnly) {
+    const filePath = join(outputPath, fileName);
+    const configContent = await readFile(filePath, "utf8").catch(() => null);
+
+    if (!configContent || configContent.trim() === "") {
+      console.log(`⚠️  No configuration found.`);
+      console.log(`🚀 Run ${chalk.cyan("aigne doc init")} to set up your documentation configuration.`);
+      process.exit(0);
+    }
+  }
+
   if (skipIfExists) {
     const filePath = join(outputPath, fileName);
     const configContent = await readFile(filePath, "utf8").catch(() => null);

--- a/agents/init/index.mjs
+++ b/agents/init/index.mjs
@@ -48,9 +48,14 @@ export default async function init(
 
     if (!configContent || configContent.trim() === "") {
       console.log(`⚠️  No configuration found.`);
-      console.log(`🚀 Run ${chalk.cyan("aigne doc init")} to set up your documentation configuration.`);
+      console.log(
+        `🚀 Run ${chalk.cyan("aigne doc init")} to set up your documentation configuration.`,
+      );
       process.exit(0);
     }
+
+    // Config exists, load and return it
+    return loadConfig({ config: filePath, appUrl });
   }
 
   if (skipIfExists) {

--- a/agents/publish/index.yaml
+++ b/agents/publish/index.yaml
@@ -8,6 +8,7 @@ skills:
   - url: ../init/index.mjs
     default_input:
       skipIfExists: true
+      checkOnly: true
   - publish-docs.mjs
 input_schema:
   type: object

--- a/agents/translate/index.yaml
+++ b/agents/translate/index.yaml
@@ -5,6 +5,7 @@ skills:
   - url: ../init/index.mjs
     default_input:
       skipIfExists: true
+      checkOnly: true
   - ../utils/load-sources.mjs
   - type: transform
     task_render_mode: hide

--- a/agents/update/index.yaml
+++ b/agents/update/index.yaml
@@ -7,6 +7,7 @@ skills:
   - url: ../init/index.mjs
     default_input:
       skipIfExists: true
+      checkOnly: true
   - ../utils/load-sources.mjs
   - type: transform
     task_render_mode: hide

--- a/agents/utils/choose-docs.mjs
+++ b/agents/utils/choose-docs.mjs
@@ -34,7 +34,9 @@ export default async function chooseDocs(
       );
 
       if (mainLanguageFiles.length === 0) {
-        throw new Error("No documents found in the docs directory");
+        throw new Error(
+          "No documents found in the docs directory, please run `aigne docs generate` to generate the documents",
+        );
       }
 
       // Convert files to choices with titles
@@ -79,10 +81,7 @@ export default async function chooseDocs(
       foundItems = await processSelectedFiles(selectedFiles, documentExecutionStructure, docsDir);
     } catch (error) {
       throw new Error(
-        getActionText(
-          isTranslate,
-          `Please provide a docs parameter to specify which documents to {action}: ${error.message}`,
-        ),
+        getActionText(isTranslate, `\nFailed to select documents to {action} - ${error.message}`),
       );
     }
   } else {

--- a/agents/utils/choose-docs.mjs
+++ b/agents/utils/choose-docs.mjs
@@ -37,15 +37,28 @@ export default async function chooseDocs(
         throw new Error("No documents found in the docs directory");
       }
 
+      // Convert files to choices with titles
+      const choices = mainLanguageFiles.map((file) => {
+        // Convert filename to flat path to find corresponding document structure item
+        const flatName = file.replace(/\.md$/, "").replace(/\.\w+(-\w+)?$/, "");
+        const docItem = documentExecutionStructure.find((item) => {
+          const itemFlattenedPath = item.path.replace(/^\//, "").replace(/\//g, "-");
+          return itemFlattenedPath === flatName;
+        });
+
+        // Use title if available, otherwise fall back to filename
+        const displayName = docItem?.title || file;
+
+        return {
+          name: displayName,
+          value: file,
+        };
+      });
+
       // Let user select multiple files
       selectedFiles = await options.prompts.checkbox({
         message: getActionText(isTranslate, "Select documents to {action}:"),
         source: (term) => {
-          const choices = mainLanguageFiles.map((file) => ({
-            name: file,
-            value: file,
-          }));
-
           if (!term) return choices;
 
           return choices.filter((choice) => choice.name.toLowerCase().includes(term.toLowerCase()));

--- a/tests/agents/utils/choose-docs.test.mjs
+++ b/tests/agents/utils/choose-docs.test.mjs
@@ -183,9 +183,7 @@ describe("chooseDocs utility", () => {
       locale: "en",
     };
 
-    await expect(chooseDocs(input, mockOptions)).rejects.toThrow(
-      "Please provide a docs parameter to specify which documents to update",
-    );
+    await expect(chooseDocs(input, mockOptions)).rejects.toThrow();
   });
 
   test("should throw error when no documents selected interactively", async () => {
@@ -199,9 +197,7 @@ describe("chooseDocs utility", () => {
       locale: "en",
     };
 
-    await expect(chooseDocs(input, mockOptions)).rejects.toThrow(
-      "Please provide a docs parameter to specify which documents to update",
-    );
+    await expect(chooseDocs(input, mockOptions)).rejects.toThrow();
   });
 
   // CHECKBOX VALIDATION TESTS

--- a/tests/utils/docs-finder-utils.test.mjs
+++ b/tests/utils/docs-finder-utils.test.mjs
@@ -15,6 +15,7 @@ import {
 describe("docs-finder-utils", () => {
   let readdirSpy;
   let readFileSpy;
+  let accessSpy;
   let joinSpy;
   let consoleWarnSpy;
 
@@ -22,6 +23,7 @@ describe("docs-finder-utils", () => {
     // Mock file system operations
     readdirSpy = spyOn(fs, "readdir").mockResolvedValue([]);
     readFileSpy = spyOn(fs, "readFile").mockResolvedValue("test content");
+    accessSpy = spyOn(fs, "access").mockResolvedValue(undefined);
     joinSpy = spyOn(path, "join").mockImplementation((...paths) => paths.join("/"));
 
     // Mock console methods
@@ -31,6 +33,7 @@ describe("docs-finder-utils", () => {
   afterEach(() => {
     readdirSpy?.mockRestore();
     readFileSpy?.mockRestore();
+    accessSpy?.mockRestore();
     joinSpy?.mockRestore();
     consoleWarnSpy?.mockRestore();
   });
@@ -606,6 +609,7 @@ describe("docs-finder-utils", () => {
     });
 
     test("getMainLanguageFiles should handle readdir errors", async () => {
+      accessSpy.mockResolvedValue(undefined); // Directory exists
       readdirSpy.mockRejectedValue(new Error("Permission denied"));
 
       await expect(getMainLanguageFiles("/denied", "en")).rejects.toThrow("Permission denied");

--- a/utils/docs-finder-utils.mjs
+++ b/utils/docs-finder-utils.mjs
@@ -1,4 +1,4 @@
-import { readdir, readFile } from "node:fs/promises";
+import { access, readdir, readFile } from "node:fs/promises";
 import { join } from "node:path";
 
 /**
@@ -120,6 +120,13 @@ export async function readFileContent(docsDir, fileName) {
  * @returns {Promise<string[]>} Array of main language .md files ordered by documentExecutionStructure
  */
 export async function getMainLanguageFiles(docsDir, locale, documentExecutionStructure = null) {
+  // Check if docsDir exists
+  try {
+    await access(docsDir);
+  } catch {
+    return [];
+  }
+
   const files = await readdir(docsDir);
 
   // Filter for main language .md files (exclude _sidebar.md)


### PR DESCRIPTION
## Related Issue

https://team.arcblock.io/comment/discussions/48d48add-6f65-46f3-9e35-40c652cae71a

### Major Changes

1. 优化 update 命令选择文档的展示，展示文档标题
2. 目录未初始化时，只有generate 命令自动执行 init ，其他命令只提醒用户未初始化

### Screenshots

update 命令选择文档，显示文档标题

<img width="566" height="320" alt="image" src="https://github.com/user-attachments/assets/576142b1-4be1-47d5-b2f4-e80eb2df26cd" />

update 命令只提醒用户当前目录未初始化，未找到配置

<img width="630" height="302" alt="image" src="https://github.com/user-attachments/assets/56aa7626-24df-453a-97ca-f46054b32f26" />




### Test Plan

- [ ] 回归 update 命令
- [ ] 验证除 generate 命令外，其他命令只提醒用户未初始化
- [ ] 回归 generate 命令仍能自动运行 init

### Checklist

- [ ] This change requires documentation updates, and I have updated the relevant documentation. If the documentation has not been updated, please create a documentation update issue and link it here
- [ ] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts
- [ ] The newly added code logic is also covered by tests
- [ ] This change adds dependencies, and they are placed in dependencies and devDependencies
- [ ] This change includes adding or updating npm dependencies, and it does not result in multiple versions of the same dependency [check the diff of pnpm-lock.yaml]
