### PR TITLE
fix: read file tool should support relative path

### DIFF
--- a/agents/update/fs-tools/read-file.mjs
+++ b/agents/update/fs-tools/read-file.mjs
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import fsPromises from "node:fs/promises";
-import path from "node:path";
+import path, { isAbsolute } from "node:path";
 
 /**
  * Detects if a file is likely binary by checking for null bytes
@@ -198,6 +198,8 @@ async function readFileContent(filePath, offset = 0, limit = null, encoding = "u
 export default async function readFile({ path: filePath, offset, limit, encoding = "utf8" }) {
   let result = {};
   let error = null;
+
+  if (filePath && !isAbsolute(filePath)) filePath = path.join(process.cwd(), filePath);
 
   try {
     // Validate file path first (this checks if it's absolute)


### PR DESCRIPTION
## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

### Major Changes

<!--
  @example:
    1. Fixed xxx
    2. Improved xxx
    3. Adjusted xxx
-->

### Screenshots

<!-- If the changes are related to the UI, whether CLI or WEB, screenshots should be included -->

### Test Plan

<!-- If this change is not covered by automated tests, what is your test case collection? Please write it as a to-do list below -->

### Checklist

- [ ] This change requires documentation updates, and I have updated the relevant documentation. If the documentation has not been updated, please create a documentation update issue and link it here
- [x] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts
- [ ] The newly added code logic is also covered by tests
- [ ] This change adds dependencies, and they are placed in dependencies and devDependencies
- [ ] This change includes adding or updating npm dependencies, and it does not result in multiple versions of the same dependency [check the diff of pnpm-lock.yaml]

<!-- This is an auto-generated comment: release notes by AIGNE CodeSmith -->
### Summary by AIGNE

Release Notes:

- New Feature: Added support for relative file paths when reading files, allowing users to specify paths relative to the current working directory
- Test: Updated test suite to accommodate and validate relative path functionality

Impact: Users can now reference files using either absolute or relative paths, providing more flexibility in file path specifications and making the API more intuitive to use.
<!-- end of auto-generated comment: release notes by AIGNE CodeSmith -->