### PR TITLE
fix: include missing locale in document check parameters

### DIFF
--- a/agents/update/check-document.mjs
+++ b/agents/update/check-document.mjs
@@ -105,6 +105,7 @@ export default async function checkDocument(
 
   const result = await options.context.invoke(teamAgent, {
     ...rest,
+    locale,
     docsDir,
     path,
     sourceIds,


### PR DESCRIPTION
## Related Issue

https://team.arcblock.io/task/task/610654234790068224

### Major Changes

1. 修复保存主语言文档的 bug

### Screenshots


### Test Plan



### Checklist

- [ ] This change requires documentation updates, and I have updated the relevant documentation. If the documentation has not been updated, please create a documentation update issue and link it here
- [ ] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts
- [ ] The newly added code logic is also covered by tests
- [ ] This change adds dependencies, and they are placed in dependencies and devDependencies
- [ ] This change includes adding or updating npm dependencies, and it does not result in multiple versions of the same dependency [check the diff of pnpm-lock.yaml]

<!-- This is an auto-generated comment: release notes by AIGNE CodeSmith -->
### Summary by AIGNE

- Bug Fix: Added locale parameter to document checking functionality to ensure proper language handling during document processing

The change ensures that document verification respects the user's language settings, providing a more localized experience. This enhancement improves the accuracy and relevance of document processing across different language contexts.
<!-- end of auto-generated comment: release notes by AIGNE CodeSmith -->