### PR TITLE
fix(publish): enhance access token retrieval and session check logic

### DIFF
--- a/agents/publish/publish-docs.mjs
+++ b/agents/publish/publish-docs.mjs
@@ -57,18 +57,20 @@ export default async function publishDocs(
     let token = "";
 
     if (!useEnvAppUrl && isDefaultAppUrl && !hasAppUrlInConfig) {
-      const authToken = await getOfficialAccessToken(BASE_URL);
+      const authToken = await getOfficialAccessToken(BASE_URL, false);
 
-      if (!authToken) {
-        throw new Error("Failed to get official access token");
+      let sessionId = "";
+      let paymentLink = "";
+
+      if (authToken) {
+        const client = new BrokerClient({ baseUrl: BASE_URL, authToken });
+        const info = await client.checkCacheSession({
+          needShortUrl: true,
+          sessionId: config?.checkoutId,
+        });
+        sessionId = info.sessionId;
+        paymentLink = info.paymentLink;
       }
-
-      const client = new BrokerClient({ baseUrl: BASE_URL, authToken });
-
-      const { sessionId, paymentLink } = await client.checkCacheSession({
-        needShortUrl: true,
-        sessionId: config?.checkoutId,
-      });
 
       const choice = await options.prompts.select({
         message: "Select platform to publish your documents:",

--- a/tests/agents/publish/publish-docs.test.mjs
+++ b/tests/agents/publish/publish-docs.test.mjs
@@ -446,39 +446,6 @@ describe("publish-docs", () => {
     expect(saveValueToConfigSpy).not.toHaveBeenCalledWith("boardId", expect.anything());
   });
 
-  // ERROR HANDLING TESTS
-  test("should handle failed official access token (null)", async () => {
-    loadConfigFromFileSpy.mockResolvedValue({});
-    getOfficialAccessTokenSpy.mockResolvedValue(null);
-    mockOptions.prompts.select.mockResolvedValue("default");
-
-    const result = await publishDocs(
-      {
-        docsDir: "./docs",
-        appUrl: "https://docsmith.aigne.io",
-      },
-      mockOptions,
-    );
-
-    expect(result.message).toBe("❌ Failed to publish docs: Failed to get official access token");
-  });
-
-  test("should handle failed official access token (undefined)", async () => {
-    loadConfigFromFileSpy.mockResolvedValue({});
-    getOfficialAccessTokenSpy.mockResolvedValue(undefined);
-    mockOptions.prompts.select.mockResolvedValue("default");
-
-    const result = await publishDocs(
-      {
-        docsDir: "./docs",
-        appUrl: "https://docsmith.aigne.io",
-      },
-      mockOptions,
-    );
-
-    expect(result.message).toBe("❌ Failed to publish docs: Failed to get official access token");
-  });
-
   test("should handle checkCacheSession failure", async () => {
     loadConfigFromFileSpy.mockResolvedValue({});
     getOfficialAccessTokenSpy.mockResolvedValue("valid-token");

--- a/utils/auth-utils.mjs
+++ b/utils/auth-utils.mjs
@@ -157,7 +157,7 @@ export async function getAccessToken(appUrl, ltToken = "") {
  * @param {string} baseUrl - The official service URL
  * @returns {Promise<string>} - The access token
  */
-export async function getOfficialAccessToken(baseUrl) {
+export async function getOfficialAccessToken(baseUrl, openPage = true) {
   // Early parameter validation
   if (!baseUrl) {
     throw new Error("baseUrl parameter is required for getOfficialAccessToken.");
@@ -188,7 +188,7 @@ export async function getOfficialAccessToken(baseUrl) {
   }
 
   // If token is found, return it
-  if (accessToken) {
+  if (accessToken || !openPage) {
     return accessToken;
   }
 


### PR DESCRIPTION
## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

### Major Changes

- 修改 accessToken 校验时刻，只有在选择自定义部署时要求获取 access token。（选项一维持一开始的逻辑，也会要求获取 token）
<!-- This is an auto-generated comment: release notes by AIGNE CodeSmith -->
### Summary by AIGNE

Release Notes:

- Refactor: Improved access token handling to make authentication optional for basic deployments
- New Feature: Added flexibility to skip browser-based authentication when not required
- Bug Fix: Removed unnecessary token validation errors for non-authenticated scenarios

These changes simplify the deployment process by making authentication optional when not needed, while maintaining secure token validation for scenarios that require it. Users can now deploy basic configurations without mandatory authentication steps.
<!-- end of auto-generated comment: release notes by AIGNE CodeSmith -->