### PR TITLE
fix: use `output` field present tool result to enhance LLM understanding

### DIFF
--- a/agents/generate/check-diagram.mjs
+++ b/agents/generate/check-diagram.mjs
@@ -1,8 +1,8 @@
 import { checkContent } from "../../utils/d2-utils.mjs";
 
-export default async function checkD2DiagramIsValid({ diagramSourceCode }) {
+export default async function checkD2DiagramIsValid({ output }) {
   try {
-    await checkContent({ content: diagramSourceCode });
+    await checkContent({ content: output });
     return {
       isValid: true,
     };
@@ -17,12 +17,12 @@ export default async function checkD2DiagramIsValid({ diagramSourceCode }) {
 checkD2DiagramIsValid.input_schema = {
   type: "object",
   properties: {
-    diagramSourceCode: {
+    output: {
       type: "string",
       description: "Source code of d2 diagram",
     },
   },
-  required: ["diagramSourceCode"],
+  required: ["output"],
 };
 checkD2DiagramIsValid.output_schema = {
   type: "object",

--- a/agents/generate/wrap-diagram-code.mjs
+++ b/agents/generate/wrap-diagram-code.mjs
@@ -4,11 +4,11 @@ export default async function wrapDiagramCode({ diagramSourceCode }) {
   try {
     const result = await wrapCode({ content: diagramSourceCode });
     return {
-      diagramSourceCode: result,
+      output: result,
     };
   } catch {
     return {
-      diagramSourceCode,
+      output: diagramSourceCode,
     };
   }
 }
@@ -26,10 +26,10 @@ wrapDiagramCode.input_schema = {
 wrapDiagramCode.output_schema = {
   type: "object",
   properties: {
-    diagramSourceCode: {
+    output: {
       type: "string",
       description: "Source code of d2 diagram",
     },
   },
-  required: ["diagramSourceCode"],
+  required: ["output"],
 };


### PR DESCRIPTION
## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

### Major Changes

<!--
  @example:
    1. Fixed xxx
    2. Improved xxx
    3. Adjusted xxx
-->

### Screenshots

<!-- If the changes are related to the UI, whether CLI or WEB, screenshots should be included -->

### Test Plan

<!-- If this change is not covered by automated tests, what is your test case collection? Please write it as a to-do list below -->

### Checklist

- [ ] This change requires documentation updates, and I have updated the relevant documentation. If the documentation has not been updated, please create a documentation update issue and link it here
- [ ] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts
- [ ] The newly added code logic is also covered by tests
- [ ] This change adds dependencies, and they are placed in dependencies and devDependencies
- [ ] This change includes adding or updating npm dependencies, and it does not result in multiple versions of the same dependency [check the diff of pnpm-lock.yaml]

<!-- This is an auto-generated comment: release notes by AIGNE CodeSmith -->
### Summary by AIGNE

**Refactor**: 
- Standardized parameter naming in diagram handling functions for better code consistency
- No functional changes or user-facing impact

This is a straightforward internal code improvement that standardizes terminology across diagram-related functions by renaming parameters from `diagramSourceCode` to `output`. The change is purely technical in nature with no impact on end-user functionality or behavior.
<!-- end of auto-generated comment: release notes by AIGNE CodeSmith -->