### PR TITLE
fix: locale not applied when generating D2 diagrams

### DIFF
--- a/agents/generate/draw-diagram.yaml
+++ b/agents/generate/draw-diagram.yaml
@@ -11,6 +11,10 @@ input_schema:
     documentContent:
       type: string
       description: The **raw text content** of the current document. (**Note:** This is the original document and **does not include** any diagram source code.)
+    locale:
+      type: string
+      description: Language for diagram labels and text
+      default: en
   required:
     - documentContent
 output_schema:

--- a/agents/update/generate-document.yaml
+++ b/agents/update/generate-document.yaml
@@ -76,6 +76,10 @@ skills:
         documentContent:
           type: string
           description: The **raw text content** of the current document. (**Note:** This is the original document and **does not include** any diagram source code.)
+        locale:
+          type: string
+          description: Language for diagram labels and text
+          default: en
       required:
         - documentContent
     output_schema:

--- a/prompts/detail/d2-diagram/user-prompt.md
+++ b/prompts/detail/d2-diagram/user-prompt.md
@@ -2,6 +2,16 @@ Follow the given rules and ISTJ style from your system instructions.
 
 Generate a d2 diagram that represents the following document content:
 
+<user_locale>
+{{ locale }}
+</user_locale>
+
+<user_rules>
+
+- Output only the diagram labels and text in the {{ locale }} language — keep all variable names, component names, and syntax unchanged.
+
+</user_rules>
+
 <document_content>
 {{documentContent}}
 </document_content>


### PR DESCRIPTION
## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

- relates https://team.arcblock.io/task/task/633119408197206016

### Major Changes

<!--
  @example:
    1. Fixed xxx
    2. Improved xxx
    3. Adjusted xxx
-->

- fix: locale not applied when generating D2 diagrams

### Screenshots

<!-- If the changes are related to the UI, whether CLI or WEB, screenshots should be included -->

- Note: Primary language is zh

<img width="1579" height="762" alt="Pasted Graphic 6" src="https://github.com/user-attachments/assets/6bde5e93-89e4-42d9-87ce-e0c5283145b4" />

### Test Plan

<!-- If this change is not covered by automated tests, what is your test case collection? Please write it as a to-do list below -->

- [x] `aigne doc generate` worked
  - [x] when generating d2 charts, use the locale language for labels. 

### Checklist

- [x] This change requires documentation updates, and I have updated the relevant documentation. If the documentation has not been updated, please create a documentation update issue and link it here
- [x] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts
- [x] The newly added code logic is also covered by tests
- [x] This change adds dependencies, and they are placed in dependencies and devDependencies
- [x] This change includes adding or updating npm dependencies, and it does not result in multiple versions of the same dependency [check the diff of pnpm-lock.yaml]
