### PR TITLE
fix: use default reasoning effort for existing config

### DIFF
--- a/agents/init/index.mjs
+++ b/agents/init/index.mjs
@@ -25,6 +25,8 @@ import { validateDocDir } from "./validate.mjs";
 
 const _PRESS_ENTER_TO_FINISH = "Press Enter to finish";
 
+const DEFAULT_REASONING_EFFORT = 502;
+
 /**
  * Guides the user through a multi-turn dialog to generate a YAML configuration file.
  * @param {Object} params
@@ -35,7 +37,7 @@ const _PRESS_ENTER_TO_FINISH = "Press Enter to finish";
 export default async function init(input, options) {
   const config = await _init(input, options);
 
-  options.context.userContext.reasoningEffort = config.reasoningEffort;
+  options.context.userContext.reasoningEffort = config.reasoningEffort || DEFAULT_REASONING_EFFORT;
 
   return config;
 }
@@ -396,7 +398,7 @@ async function _init(
   input.projectDesc = projectInfo.description;
   input.projectLogo = projectInfo.icon;
 
-  input.reasoningEffort = 502; // Default reasoning effort for init process
+  input.reasoningEffort = DEFAULT_REASONING_EFFORT;
 
   // Generate YAML content
   const yamlContent = generateYAML(input, outputPath);


### PR DESCRIPTION
## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

### Major Changes

<!--
  @example:
    1. Fixed xxx
    2. Improved xxx
    3. Adjusted xxx
-->

### Screenshots

<!-- If the changes are related to the UI, whether CLI or WEB, screenshots should be included -->

### Test Plan

<!-- If this change is not covered by automated tests, what is your test case collection? Please write it as a to-do list below -->

### Checklist

- [ ] This change requires documentation updates, and I have updated the relevant documentation. If the documentation has not been updated, please create a documentation update issue and link it here
- [ ] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts
- [ ] The newly added code logic is also covered by tests
- [ ] This change adds dependencies, and they are placed in dependencies and devDependencies
- [ ] This change includes adding or updating npm dependencies, and it does not result in multiple versions of the same dependency [check the diff of pnpm-lock.yaml]

<!-- This is an auto-generated comment: release notes by AIGNE CodeSmith -->
### Summary by AIGNE

## Release Notes

**Refactor:**
- Improved reasoning effort configuration handling by introducing a default fallback value (502) when not explicitly specified in the configuration

**Bug Fix:**
- Fixed potential issues where undefined reasoning effort configuration could cause unexpected behavior in the initialization process

This change ensures more reliable agent initialization by providing consistent default behavior when reasoning effort parameters are not configured.
<!-- end of auto-generated comment: release notes by AIGNE CodeSmith -->