### PR TITLE
fix: replace direct reasoning effort with thinking effort tiers

### DIFF
--- a/agents/utils/map-reasoning-effort-level.mjs
+++ b/agents/utils/map-reasoning-effort-level.mjs
@@ -1,0 +1,15 @@
+import {
+  DEFAULT_REASONING_EFFORT_LEVEL,
+  DEFAULT_REASONING_EFFORT_VALUE,
+  REASONING_EFFORT_LEVELS,
+} from "../../utils/constants/index.mjs";
+
+export default function mapReasoningEffortLevel({ level }, options) {
+  const g =
+    REASONING_EFFORT_LEVELS[level] || REASONING_EFFORT_LEVELS[DEFAULT_REASONING_EFFORT_LEVEL];
+
+  return {
+    reasoningEffort:
+      g[options.context.userContext.thinkingEffort] ?? DEFAULT_REASONING_EFFORT_VALUE,
+  };
+}

--- a/utils/constants/index.mjs
+++ b/utils/constants/index.mjs
@@ -555,3 +555,35 @@ export const DOC_ACTION = {
   update: "update",
   clear: "clear",
 };
+
+// Default thinking effort level, available options: 'lite', 'standard', 'pro'
+// This level can be defined by the user in the config file to influence reasoning effort mapping
+export const DEFAULT_THINKING_EFFORT_LEVEL = "standard";
+
+// Default reasoning effort level, available options: 'minimal', 'low', 'medium', 'high'
+export const DEFAULT_REASONING_EFFORT_LEVEL = "low";
+
+export const DEFAULT_REASONING_EFFORT_VALUE = 500;
+
+export const REASONING_EFFORT_LEVELS = {
+  minimal: {
+    lite: 100,
+    standard: 300,
+    pro: 500,
+  },
+  low: {
+    lite: 200,
+    standard: 500,
+    pro: 1000,
+  },
+  medium: {
+    lite: 300,
+    standard: 800,
+    pro: 1500,
+  },
+  high: {
+    lite: 500,
+    standard: 1000,
+    pro: 2000,
+  },
+};


### PR DESCRIPTION
## Related Issue

<!-- Use keywords like fixes, closes, resolves, relates to link the issue. In principle, all PRs should be associated with an issue -->

fix https://github.com/AIGNE-io/aigne-doc-smith/issues/262

### Major Changes

<!--
  @example:
    1. Fixed xxx
    2. Improved xxx
    3. Adjusted xxx
-->

### Screenshots

<!-- If the changes are related to the UI, whether CLI or WEB, screenshots should be included -->

### Test Plan

<!-- If this change is not covered by automated tests, what is your test case collection? Please write it as a to-do list below -->

### Checklist

- [ ] This change requires documentation updates, and I have updated the relevant documentation. If the documentation has not been updated, please create a documentation update issue and link it here
- [ ] The changes are already covered by tests, and I have adjusted the test coverage for the changed parts
- [ ] The newly added code logic is also covered by tests
- [ ] This change adds dependencies, and they are placed in dependencies and devDependencies
- [ ] This change includes adding or updating npm dependencies, and it does not result in multiple versions of the same dependency [check the diff of pnpm-lock.yaml]

<!-- This is an auto-generated comment: release notes by AIGNE CodeSmith -->
### Summary by AIGNE

## Release Notes

**Refactor: Simplified reasoning effort configuration**
- Replaced numeric `reasoningEffort` values with intuitive string-based `thinking.effort` levels
- Users can now specify effort as "minimal", "low", "medium", or "high" instead of arbitrary numbers
- Effort levels automatically map to appropriate user tiers (lite, standard, pro)
- Default configuration updated to use "standard" effort level for better user experience

This change makes AI reasoning configuration more user-friendly and self-explanatory.
<!-- end of auto-generated comment: release notes by AIGNE CodeSmith -->